### PR TITLE
Fix support for OSX "Spaces"

### DIFF
--- a/Nagstamon/resources/Info.plist
+++ b/Nagstamon/resources/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleDisplayName</key>
 	<string>Nagstamon</string>
 	<key>CFBundleIdentifier</key>
-	<string></string>
+	<string>de.ifw-dresden.nagstamon</string>
 	<key>NSHighResolutionCapable</key>
 	<true/>
 </dict>


### PR DESCRIPTION
Adding a CFBundleIdentifier value actives the right-click "Assign To" menu for Nagstamon in the Dock.
